### PR TITLE
Fixes csrf token check

### DIFF
--- a/EventListener/LdapListener.php
+++ b/EventListener/LdapListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface,
 ;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class LdapListener extends AbstractAuthenticationListener
@@ -77,9 +78,9 @@ class LdapListener extends AbstractAuthenticationListener
         }
 
         if (null !== $this->csrfProvider) {
-            $csrfToken = $request->get($this->options['csrf_parameter'], null, true);
+            $csrfToken = new CsrfToken($this->options['intention'], $request->get($this->options['csrf_parameter'], null, true));
 
-            if (false === $this->csrfProvider->isCsrfTokenValid($this->options['intention'], $csrfToken)) {
+            if (false === $this->csrfProvider->isTokenValid($csrfToken)) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }


### PR DESCRIPTION
CsrfTokenManagerInterface does not provide "isCsrfTokenValid" but "isTokenValid", using a CsrfToken object