### PR TITLE
Removes deprecated $deep param from Request::get()

### DIFF
--- a/EventListener/LdapListener.php
+++ b/EventListener/LdapListener.php
@@ -77,15 +77,15 @@ class LdapListener extends AbstractAuthenticationListener
         }
 
         if (null !== $this->csrfProvider) {
-            $csrfToken = $request->get($this->options['csrf_parameter'], null, true);
+            $csrfToken = $request->get($this->options['csrf_parameter']);
 
             if (false === $this->csrfProvider->isCsrfTokenValid($this->options['intention'], $csrfToken)) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }
 
-        $username = trim($request->get($this->options['username_parameter'], null, true));
-        $password = $request->get($this->options['password_parameter'], null, true);
+        $username = trim($request->get($this->options['username_parameter']));
+        $password = $request->get($this->options['password_parameter']);
 
         $request->getSession()->set(Security::LAST_USERNAME, $username);
 


### PR DESCRIPTION
Using paths to find deeper items (3rd param `true`) in Symfony\Component\HttpFoundation\Request::get is deprecated since Symfony 2.8 and will be removed in 3.0.